### PR TITLE
fix a couple of bugs

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -131,7 +131,6 @@ for w in worker_config.iterkeys():
 
 ####### SCHEDULERS
 checkin = schedulers.SingleBranchScheduler(name="checkin",
-                                           treeStableTimer=10,
                                            change_filter=util.ChangeFilter(branch='master',
                                                                            project_re=r'^flathub/.*\..*\..*'),
                                            builderNames=["Build App"])

--- a/master.cfg
+++ b/master.cfg
@@ -105,7 +105,7 @@ c['workers'] = []
 # For whatever reason, max-builds doesn't seem to work, so we only ever run one build.
 # To hack around this we create multiple master workers
 local_workers = []
-for i in range(1,flathub_num_master_workers):
+for i in range(1,flathub_num_master_workers+1):
     name = 'MasterWorker%d' % i
     c['workers'].append (worker.LocalWorker(name))
     local_workers.append(name)


### PR DESCRIPTION
Switch off the treeStableTimer so we build every push, because consecutive pushes could be different repos. Fix the LocalWorker loop so we actually get flathub_num_master_workers of workers.