### PR TITLE
Support multiple builds of the same arch on one worker

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -44,6 +44,11 @@ flathub_github_change_secret = getConfig('github-change-secret')
 flathub_github_status_token = getConfig('github-status-token')
 flathub_keep_builds = getConfig('keep-builds', False)
 
+# Buildbot does unique builds per build + worker, so if we want a single worker
+# to build multiple apps of the same arch, then we need to have multiple build
+# ids for each arch, so we append a number which we calculate from the build id
+num_builders_per_arch = 16
+
 # Tracks the last build number that was used to update the repo for a particular build-id
 # So we avoid going backwards if the builds finish in the wrong order
 flathub_build_latest_update = {}
@@ -116,7 +121,7 @@ build_workers = []
 for w in worker_config.iterkeys():
     wc = worker_config[w]
     passwd = wc['password']
-    max_builds = None
+    max_builds = 1
     if wc.has_key('max-builds'):
         max_builds = wc['max-builds']
     c['workers'].append (worker.Worker(w, passwd, max_builds=max_builds))
@@ -150,9 +155,19 @@ checkin = schedulers.AnyBranchScheduler(name="checkin",
                                         change_filter=util.ChangeFilter(filter_fn=change_should_build),
                                         builderNames=["Build App"])
 
+def getArchBuilderName(arch, buildnr):
+    b = buildnr % num_builders_per_arch
+    if b == 0:
+        build_extra = ""
+    else:
+        build_extra = "-%s" % b
+
+    return "build-" + arch + build_extra
+
 @util.renderer
 def computeBuildArches(props):
-    return map(lambda x: "build-" + x, props.getProperty("flathub-arches", []))
+    buildnr = props.getProperty ('flathub-buildnumber', 0)
+    return map(lambda arch: getArchBuilderName(arch, buildnr), props.getProperty("flathub-arches", []))
 
 build = schedulers.Triggerable(name="build-all-platforms",
                                builderNames=computeBuildArches)
@@ -779,11 +794,12 @@ for arch in flathub_arches:
     if arch == 'x86_64':
         extra_fb_args = extra_fb_args + ['--bundle-sources']
 
-    c['builders'].append(
-        util.BuilderConfig(name='build-' + arch,
-                           workernames=flathub_arch_workers[arch],
-                           properties={'flathub-arch': arch, 'extra-fb-args': extra_fb_args },
-                           factory=build_factory))
+    for i in range(0, num_builders_per_arch):
+        c['builders'].append(
+            util.BuilderConfig(name=getArchBuilderName(arch, i),
+                               workernames=flathub_arch_workers[arch],
+                               properties={'flathub-arch': arch, 'extra-fb-args': extra_fb_args },
+                               factory=build_factory))
     status_builders.append('build-' + arch)
 c['builders'].append(
     util.BuilderConfig(name='update-repo',


### PR DESCRIPTION
We do this by artificially creating multiple builders for each
arch, indexed by the build id. We start with 16 of them, meaning
that up to 16 consecutive builds can be started in parallel on
the same worker.