### PR TITLE
Add GNOME compatibility for the KDE runtime

### DIFF
--- a/builds.json
+++ b/builds.json
@@ -32,37 +32,31 @@
         },
         "org.kde.KStyle.Adwaita/5.9": {
             "repo": "kde",
-            "base": "org.freedesktop.Sdk/1.6",
             "git-module": "flatpak-kde-runtime.git",
             "git-branch": "qt5.9lts"
         },
         "org.kde.KStyle.Adwaita/5.10": {
             "repo": "kde",
-            "base": "org.freedesktop.Sdk/1.6",
             "git-module": "flatpak-kde-applications.git",
             "git-branch": "master"
         },
         "org.kde.KStyle.HighContrast/5.9": {
             "repo": "kde",
-            "base": "org.freedesktop.Sdk/1.6",
             "git-module": "flatpak-kde-runtime.git",
             "git-branch": "qt5.9lts"
         },
         "org.kde.KStyle.HighContrast/5.10": {
             "repo": "kde",
-            "base": "org.freedesktop.Sdk/1.6",
             "git-module": "flatpak-kde-applications.git",
             "git-branch": "master"
         },
         "org.kde.PlatformTheme.QGnomePlatform/5.9": {
             "repo": "kde",
-            "base": "org.freedesktop.Sdk/1.6",
             "git-module": "flatpak-kde-runtime.git",
             "git-branch": "qt5.9lts"
         },
         "org.kde.PlatformTheme.QGnomePlatform/5.10": {
             "repo": "kde",
-            "base": "org.freedesktop.Sdk/1.6",
             "git-module": "flatpak-kde-applications.git",
             "git-branch": "master"
         },

--- a/builds.json
+++ b/builds.json
@@ -31,33 +31,33 @@
             "git-branch": "master"
         },
         "org.kde.KStyle.Adwaita/5.9": {
-            "repo": "kde",
-            "git-module": "flatpak-kde-runtime.git",
+            "repo": "default",
+            "git-module": "org.kde.KStyle.Adwaita.git",
             "git-branch": "qt5.9lts"
         },
         "org.kde.KStyle.Adwaita/5.10": {
-            "repo": "kde",
-            "git-module": "flatpak-kde-runtime.git",
+            "repo": "default",
+            "git-module": "org.kde.KStyle.Adwaita.git",
             "git-branch": "master"
         },
         "org.kde.KStyle.HighContrast/5.9": {
-            "repo": "kde",
-            "git-module": "flatpak-kde-runtime.git",
+            "repo": "default",
+            "git-module": "org.kde.KStyle.HighContrast.git",
             "git-branch": "qt5.9lts"
         },
         "org.kde.KStyle.HighContrast/5.10": {
-            "repo": "kde",
-            "git-module": "flatpak-kde-runtime.git",
+            "repo": "default",
+            "git-module": "org.kde.KStyle.HighContrast.git",
             "git-branch": "master"
         },
         "org.kde.PlatformTheme.QGnomePlatform/5.9": {
-            "repo": "kde",
-            "git-module": "flatpak-kde-runtime.git",
+            "repo": "default",
+            "git-module": "org.kde.PlatformTheme.QGnomePlatform.git",
             "git-branch": "qt5.9lts"
         },
         "org.kde.PlatformTheme.QGnomePlatform/5.10": {
-            "repo": "kde",
-            "git-module": "flatpak-kde-runtime.git",
+            "repo": "default",
+            "git-module": "org.kde.PlatformTheme.QGnomePlatform.git",
             "git-branch": "master"
         },
         "org.freedesktop.Platform.GL.nvidia": {

--- a/builds.json
+++ b/builds.json
@@ -30,6 +30,42 @@
             "git-module": "flatpak-kde-runtime.git",
             "git-branch": "master"
         },
+        "org.kde.KStyle.Adwaita/5.9": {
+            "repo": "kde",
+            "base": "org.freedesktop.Sdk/1.6",
+            "git-module": "flatpak-kde-runtime.git",
+            "git-branch": "qt5.9lts"
+        },
+        "org.kde.KStyle.Adwaita/5.10": {
+            "repo": "kde",
+            "base": "org.freedesktop.Sdk/1.6",
+            "git-module": "flatpak-kde-applications.git",
+            "git-branch": "master"
+        },
+        "org.kde.KStyle.HighContrast/5.9": {
+            "repo": "kde",
+            "base": "org.freedesktop.Sdk/1.6",
+            "git-module": "flatpak-kde-runtime.git",
+            "git-branch": "qt5.9lts"
+        },
+        "org.kde.KStyle.HighContrast/5.10": {
+            "repo": "kde",
+            "base": "org.freedesktop.Sdk/1.6",
+            "git-module": "flatpak-kde-applications.git",
+            "git-branch": "master"
+        },
+        "org.kde.PlatformTheme.QGnomePlatform/5.9": {
+            "repo": "kde",
+            "base": "org.freedesktop.Sdk/1.6",
+            "git-module": "flatpak-kde-runtime.git",
+            "git-branch": "qt5.9lts"
+        },
+        "org.kde.PlatformTheme.QGnomePlatform/5.10": {
+            "repo": "kde",
+            "base": "org.freedesktop.Sdk/1.6",
+            "git-module": "flatpak-kde-applications.git",
+            "git-branch": "master"
+        },
         "org.freedesktop.Platform.GL.nvidia": {
             "repo": "flatpak",
             "git-module": "freedesktop-sdk-images.git",

--- a/builds.json
+++ b/builds.json
@@ -37,7 +37,7 @@
         },
         "org.kde.KStyle.Adwaita/5.10": {
             "repo": "kde",
-            "git-module": "flatpak-kde-applications.git",
+            "git-module": "flatpak-kde-runtime.git",
             "git-branch": "master"
         },
         "org.kde.KStyle.HighContrast/5.9": {
@@ -47,7 +47,7 @@
         },
         "org.kde.KStyle.HighContrast/5.10": {
             "repo": "kde",
-            "git-module": "flatpak-kde-applications.git",
+            "git-module": "flatpak-kde-runtime.git",
             "git-branch": "master"
         },
         "org.kde.PlatformTheme.QGnomePlatform/5.9": {
@@ -57,7 +57,7 @@
         },
         "org.kde.PlatformTheme.QGnomePlatform/5.10": {
             "repo": "kde",
-            "git-module": "flatpak-kde-applications.git",
+            "git-module": "flatpak-kde-runtime.git",
             "git-branch": "master"
         },
         "org.freedesktop.Platform.GL.nvidia": {


### PR DESCRIPTION
This aims to solve #24 by adding the manifests for the GNOME desktop integration hosted by the KDE SDK team.

note: the KDE repo doesn't currently have a 5.10 version, the 5.9 version is on master. But we need to make sure that this applies to each runtime hosted on Flathub and following the same style as the SDK seems to make sense.