### PR TITLE
Add download-sources steps

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -6,6 +6,7 @@ from future.utils import string_types
 from buildbot.process.build import Build
 from buildbot.plugins import *
 from buildbot.process import logobserver
+from buildbot.process import remotecommand
 from buildbot import locks
 from twisted.python import log
 from twisted.internet import defer
@@ -36,6 +37,8 @@ flathub_num_master_workers = getConfig('num-master-workers', 4)
 flathub_buildbot_uri = getConfig('buildbot-uri')
 flathub_upstream_repo = getConfig('flathub-repo')
 flathub_upstream_repo_path = getConfig('flathub-repo-path')
+flathub_upstream_sources_uri = getConfig('flathub-sources-uri', os.path.join (flathub_upstream_repo, "sources" ))
+flathub_upstream_sources_path = getConfig('flathub-sources-path', os.path.join (flathub_upstream_repo_path, "sources" ))
 flathub_branch = getConfig('flathub-branch')
 flathub_gpg_homedir = getConfig('flathub-gpg-homedir')
 flathub_gpg_key = getConfig('flathub-gpg-key')
@@ -123,6 +126,8 @@ for w in worker_config.iterkeys():
     wc = worker_config[w]
     passwd = wc['password']
     max_builds = 1
+    if wc.has_key('update-repo'):
+        max_builds = 2 # Default to 2 for update-repo worker, so we can both update and download at the same time
     if wc.has_key('max-builds'):
         max_builds = wc['max-builds']
     wk = worker.Worker(w, passwd, max_builds=max_builds)
@@ -145,7 +150,6 @@ def get_canonical_uri(repo_uri):
     if alt_url:
             return alt_url
     return repo_uri
-
 
 def change_should_build(change):
     try:
@@ -191,6 +195,8 @@ build = schedulers.Triggerable(name="build-all-platforms",
                                builderNames=computeBuildArches)
 update_repo = schedulers.Triggerable(name="update-repo",
                                      builderNames=["update-repo"])
+download_sources = schedulers.Triggerable(name="download-sources",
+                                     builderNames=["download-sources"])
 
 class AppParameter(util.CodebaseParameter):
 
@@ -272,7 +278,7 @@ force = schedulers.ForceScheduler(
     ]
 )
 
-c['schedulers'] = [checkin, build, update_repo, force]
+c['schedulers'] = [checkin, build, update_repo, download_sources, force]
 c['collapseRequests'] = False
 
 ####### Custom builders
@@ -382,12 +388,13 @@ class FlatpakBuildStep(buildbot.process.buildstep.ShellMixin, steps.BuildStep):
                    '--user', '--install-deps-from=flathub',
                    util.Property('extra-fb-args'),
                    '--mirror-screenshots-url=https://flathub.org/repo/screenshots', '--repo', 'repo',
+                   '--extra-sources-url=' + flathub_upstream_sources_uri,
                    util.Interpolate('--extra-sources=%(prop:builddir)s/../downloads'),
                    '--default-branch', util.Property('flathub-branch'),
                    '--subject', util.Property('flathub-subject'),
                    'builddir', util.Interpolate('%(prop:flathub-manifest)s')]
         if props.getProperty("flathub-custom-buildcmd", False):
-            command = ['./build.sh', util.Property('flathub-arch'), 'repo', '', util.Interpolate('--sandbox --delete-build-dirs --user --install-deps-from=flathub --extra-sources=%(prop:builddir)s/../downloads '), util.Property('flathub-subject')]
+            command = ['./build.sh', util.Property('flathub-arch'), 'repo', '', util.Interpolate('--sandbox --delete-build-dirs --user --install-deps-from=flathub --extra-sources-url='+ flathub_upstream_sources_uri +' --extra-sources=%(prop:builddir)s/../downloads '), util.Property('flathub-subject')]
 
         rendered=yield self.build.properties.render(command)
         cmd = yield self.makeRemoteShellCommand(command=rendered)
@@ -620,6 +627,63 @@ def computeBuildCommitFromArgs(props):
     args = args + ["import-repo"]
     return args
 
+class FlatpakDownloadStep(buildbot.process.buildstep.ShellMixin, steps.BuildStep):
+    def __init__(self, **kwargs):
+        self.setupShellMixin({'logEnviron': False,
+                              'timeout': 3600,
+                              'usePTY': True})
+        steps.BuildStep.__init__(self, haltOnFailure = True, **kwargs)
+        self.title = u"Building"
+
+    @defer.inlineCallbacks
+    def run(self):
+        props = self.build.properties
+        id = props.getProperty("flathub-id")
+        self.title = u"Downloading sources for %s" % id
+        self.result_title = u"Failed to download sources for %s" % id
+        self.updateSummary()
+        if props.getProperty("flathub-custom-buildcmd", False):
+            # Check for flathub-download.sh and only run if it exists
+            statCmd = remotecommand.RemoteCommand('stat', {'file': './flathub-download.sh'})
+            yield self.runCommand(statCmd)
+            if statCmd.didFail():
+                self.result_title = u"Skipping download due to missing flathub-download.sh"
+                defer.returnValue(buildbot.process.results.SKIPPED)
+                return
+
+            command = ['./flathub-download.sh', flathub_upstream_sources_path]
+        else:
+            command = ['flatpak-builder', '--download-only', '--no-shallow-clone',
+                       '--state-dir=' + flathub_upstream_sources_path,
+                       'builddir', util.Interpolate('%(prop:flathub-manifest)s')]
+
+        rendered=yield self.build.properties.render(command)
+        cmd = yield self.makeRemoteShellCommand(command=rendered)
+        yield self.runCommand(cmd)
+
+        if not cmd.didFail():
+            self.result_title = u"Downloaded sources for %s" % id
+
+        defer.returnValue(cmd.results())
+
+    def getCurrentSummary(self):
+        return {u'step': self.title}
+
+    def getResultSummary(self):
+        return {u'step': self.result_title}
+
+download_sources_factory = util.BuildFactory()
+download_sources_factory.addSteps([
+    steps.SetProperty(name='Rewrite url',property="repository", value=computeRepoUrl),
+    steps.Git(name="checkout manifest",
+              logEnviron=False,
+              repourl=util.Property('repository'),
+              mode='incremental', branch='master', submodules=True),
+    steps.ShellCommand(name='ensure source dir', logEnviron=False,
+                       command=['mkdir', '-p', flathub_upstream_repo_path + '/sources']),
+    FlatpakDownloadStep(name='Download')
+])
+
 
 update_repo_factory = util.BuildFactory()
 update_repo_factory.addSteps([
@@ -779,6 +843,28 @@ build_app_factory.addSteps([
     steps.SetPropertyFromCommand(command="git show --format=%s -s $(git rev-list --no-merges -n 1 HEAD)",
                                  property="git-subject", logEnviron=False),
     FlathubPropertiesStep(name="Set flathub properties"),
+    steps.Trigger(name='Download sources',
+                  haltOnFailure=True,
+                  doStepIf=ShouldUpdateRepo,
+                  hideStepIf=hide_on_skipped,
+                  schedulerNames=['download-sources'],
+                  updateSourceStamp=True,
+                  waitForFinish=True,
+                  set_properties={
+                      'flathub-id' : util.Property('flathub-id'),
+                      'flathub-arches' : util.Property('flathub-arches'),
+                      'flathub-build-id' : util.Property('flathub-build-id'),
+                      'flathub-buildnumber' : util.Property('flathub-buildnumber'),
+                      'flathub-artifact-dir' : util.Property('flathub-artifact-dir'),
+                      'flathub-manifest' : util.Property('flathub-manifest'),
+                      'flathub-branch' : util.Property('flathub-branch'),
+                      'flathub-custom-buildcmd' : util.Property('flathub-custom-buildcmd'),
+                      'flathub-official-build' : util.Property('flathub-official-build'),
+                      'flathub-desc' : util.Property('flathub-desc'),
+                      'flathub-subject' : util.Property('flathub-subject'),
+                      'flathub-config' : util.Property('flathub-config'),
+                      'reason' : util.Property('flathub-buildnumber')
+                  }),
     steps.Trigger(name='Build all platforms',
                   haltOnFailure=True,
                   schedulerNames=['build-all-platforms'],
@@ -864,6 +950,11 @@ c['builders'].append(
                        workernames=flathub_update_workers,
                        factory=update_repo_factory))
 status_builders.append('update-repo')
+c['builders'].append(
+    util.BuilderConfig(name='download-sources',
+                       workernames=flathub_update_workers,
+                       factory=download_sources_factory))
+status_builders.append('download-sources')
 c['builders'].append(
     util.BuilderConfig(name='Build App',
                        collapseRequests=True,


### PR DESCRIPTION
This is run for official builds and runs --download-only into $repourl/sources, which makes
a copy of all the sources ever used in flathub builds. We then pass --extra-source-url to
the builds, allowing them to use this cache, both for speed, and reproducibility if the
network source goes offline.