### PR TITLE
Allow app sub-IDs to pass trivial appdata check

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -467,7 +467,7 @@ def create_build_factory():
             doStepIf=lambda step: not step.build.getProperty('flathub-config', {}).get("skip-appstream-check"),
             haltOnFailure=True,
             logEnviron=False,
-            command=util.Interpolate('zgrep "<id>%(prop:flathub-id)s\\(.desktop\\)\\?</id>" builddir/*/share/app-info/xmls/%(prop:flathub-id)s.xml.gz')),
+            command=util.Interpolate('zgrep "<id>%(prop:flathub-id)s\\(\\.\\w\\+\\)*\\(.desktop\\)\\?</id>" builddir/*/share/app-info/xmls/%(prop:flathub-id)s.xml.gz')),
         steps.ShellCommand(
             name='Check that the right branch was built',
             haltOnFailure=True,


### PR DESCRIPTION
org.gnome.Weather ships an app ID org.gnome.Weather.Application for whatever
reasons. Allow sub-IDs to pass the check that the appdata contains the app ID.
(see https://github.com/flathub/org.gnome.Weather/pull/3)