### PR TITLE
Add electron 1.6 branches

### DIFF
--- a/builds.json
+++ b/builds.json
@@ -124,6 +124,16 @@
             "repo": "default",
             "git-module": "io.atom.electron.BaseApp.git",
             "git-branch": "1.6"
+        },
+        "org.electronjs.Electron2.BaseApp/18.08": {
+            "repo": "default",
+            "git-module": "org.electronjs.Electron2.BaseApp.git",
+            "git-branch": "master"
+        },
+        "io.atom.electron.BaseApp/18.08": {
+            "repo": "default",
+            "git-module": "io.atom.electron.BaseApp.git",
+            "git-branch": "master"
         }
     },
     "imports": {

--- a/builds.json
+++ b/builds.json
@@ -114,6 +114,16 @@
             "git-branch": "gnome-3-28",
             "base": "org.freedesktop.Sdk/1.6",
             "custom-buildcmd": true
+        },
+        "org.electronjs.Electron2.BaseApp/stable": {
+            "repo": "default",
+            "git-module": "org.electronjs.Electron2.BaseApp.git",
+            "git-branch": "1.6"
+        },
+        "io.atom.electron.BaseApp/stable": {
+            "repo": "default",
+            "git-module": "io.atom.electron.BaseApp.git",
+            "git-branch": "1.6"
         }
     },
     "imports": {


### PR DESCRIPTION
This allows master to move to 18.08 while still being able to support the 1.6 version.