### PR TITLE
Add --disable-fsync in varios places to speed things up

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -493,9 +493,9 @@ def create_build_factory():
             commands=[
                 # Merge the two into a new repo
                 shellArg(['ostree', '--repo=merged-repo', 'init', '--mode=archive-z2']),
-                shellArg(['ostree', 'pull-local', '--repo=merged-repo', 'flathub-repo']),
+                shellArg(['ostree', 'pull-local', '--disable-fsync', '--repo=merged-repo', 'flathub-repo']),
                 shellArg(['rm', '-rf', 'flathub-repo']),
-                shellArg(['flatpak', 'build-commit-from', '--src-repo=repo', 'merged-repo']),
+                shellArg(['flatpak', 'build-commit-from', '--disable-fsync', '--src-repo=repo', 'merged-repo']),
                 # Switch merged-repo to 'repo', which is later packed up as the build result
                 shellArg(['rm', '-rf', 'repo']),
                 shellArg(['mv', 'merged-repo', 'repo'])
@@ -620,7 +620,7 @@ class AddArchSteps(steps.BuildStep):
 @util.renderer
 def computeBuildCommitFromArgs(props):
     eol = props.getProperty ('flathub-config', {}).get("end-of-life", None)
-    args = ['flatpak', 'build-commit-from', '--timestamp=NOW', '--src-repo=repo', '--no-update-summary']
+    args = ['flatpak', 'build-commit-from', '--timestamp=NOW', '--disable-fsync', '--src-repo=repo', '--no-update-summary']
     if eol:
         args = args + [ "--force", "--end-of-life=%s" % (eol) ]
     args = args + gpg_args
@@ -707,7 +707,7 @@ update_repo_factory.addSteps([
         shellArg(['ostree', '--repo=import-repo', '--mode=archive-z2', 'init']),
         # Hardlink-import all the newly downloaded objects, for faster lookups
         shellArg(['ostree', '--repo=repo', 'summary', '-u']), # Need this for pull-local
-        shellArg(['ostree', '--repo=import-repo', 'pull-local', 'repo']),
+        shellArg(['ostree', '--repo=import-repo', '--disable-fsync', 'pull-local', 'repo']),
         shellArg('rm -rf import-repo/refs/heads/*'),
         shellArg('if ostree config --repo=' + flathub_upstream_repo_path + ' get core.collection-id > /dev/null; then ostree config --repo=import-repo set core.collection-id $(ostree config --repo=' + flathub_upstream_repo_path + ' get core.collection-id) ; fi'),
         shellArg(['ostree', '--repo=import-repo', 'config', 'set', 'core.parent', flathub_upstream_repo_path]),


### PR DESCRIPTION
This happens on the builder:
 * When pulling the old version of the merge-repo into the builder
 * When rebasing the app on top of that

And in update-repo:
 * When pulling the current repo into import-repo
 * When commiting from the downloaded (bare) repo into the archive-z2 repo