### PR TITLE
Use "soft purge" for invalidating summary file on CDN

### DIFF
--- a/scripts/post-update-repo.sh
+++ b/scripts/post-update-repo.sh
@@ -29,4 +29,4 @@ for arch in $(ostree --repo=$REPO refs appstream); do
     ostree --repo=$REPO checkout -U --union appstream/$arch $REPO/appstream/$arch;
 done
 
-curl --connect-to dl.flathub.org::dl.flathub.org: -X PURGE https://dl.flathub.org/repo/summary{,.sig} || true
+curl -X PURGE -H "Fastly-Soft-Purge: 1" https://dl.flathub.org/repo/summary{,.sig} || true


### PR DESCRIPTION
As the summary file has a very low cache lifetime (one minute), if there is any temporary problem reaching the origin server, the CDN gives 503 errors for the summary after one minute. We've added "stale-if-error" to the Surrogate-Control header on the repo master, but this will have no effect if the summary file is explicitly purged from the CDN. Use the "soft purge" to mark the summary as needing refreshing immediately, but keep the stale object so it can be served in this situation. See https://docs.fastly.com/guides/purging/soft-purges.