### PR TITLE
 General handling of non-stable branches 

### DIFF
--- a/builds.json
+++ b/builds.json
@@ -152,16 +152,6 @@
             "git-module": "io.qt.qtwebkit.BaseApp.git",
             "git-branch": "5.11"
         },
-        "org.freedesktop.Sdk.Extension.golang/1.6": {
-            "repo": "default",
-            "git-module": "org.freedesktop.Sdk.Extension.golang.git",
-            "git-branch": "1.6"
-        },
-        "org.freedesktop.Sdk.Extension.golang/18.08": {
-            "repo": "default",
-            "git-module": "org.freedesktop.Sdk.Extension.golang.git",
-            "git-branch": "18.08"
-        },
         "io.liri.BaseApp/5.11": {
             "repo": "default",
             "git-module": "io.liri.BaseApp.git",


### PR DESCRIPTION
If no build is otherwise configured for this id, then if the
git branch is of the form "branch/FOO", then we take this to mean
that the flatpak branch should be FOO. And vice versa, when going
from buildname like "org.some.app/FOO" we assume you want the
git branch "branch/FOO".

This allows regular github repos to have multiple branches, for
example base apps.