### PR TITLE
Move Nvidia driver to its own repo

### DIFF
--- a/builds.json
+++ b/builds.json
@@ -82,9 +82,9 @@
             "git-branch": "master"
         },
         "org.freedesktop.Platform.GL.nvidia": {
-            "repo": "flatpak",
-            "git-module": "freedesktop-sdk-images.git",
-            "git-branch": "nvidia-drivers",
+            "repo": "default",
+            "git-module": "org.freedesktop.Platform.GL.nvidia.git",
+            "git-branch": "master",
             "only-arches": ["x86_64","i386"],
             "custom-buildcmd": true
         },

--- a/builds.json
+++ b/builds.json
@@ -85,7 +85,6 @@
             "repo": "default",
             "git-module": "org.freedesktop.Platform.GL.nvidia.git",
             "git-branch": "master",
-            "only-arches": ["x86_64","i386"],
             "custom-buildcmd": true
         },
         "org.freedesktop.BaseSdk/1.6": {


### PR DESCRIPTION
I think we are past the point where it makes any sense to keep the nvidia drivers in the same repo as the 1.6 runtime.

I'll set it up on flathub after this is merged.