### PR TITLE
Introduce Qt 5.12

### DIFF
--- a/builds.json
+++ b/builds.json
@@ -40,7 +40,7 @@
             "repo": "kde",
             "base": "org.freedesktop.Sdk/18.08",
             "git-module": "flatpak-kde-runtime.git",
-            "git-branch": "master"
+            "git-branch": "qt5.12lts"
         },
         "org.kde.KStyle.Adwaita/5.9": {
             "repo": "default",

--- a/builds.json
+++ b/builds.json
@@ -34,6 +34,12 @@
             "repo": "kde",
             "base": "org.freedesktop.Sdk/1.6",
             "git-module": "flatpak-kde-runtime.git",
+            "git-branch": "qt5.11"
+        },
+        "org.kde.Sdk/5.12": {
+            "repo": "kde",
+            "base": "org.freedesktop.Sdk/18.08",
+            "git-module": "flatpak-kde-runtime.git",
             "git-branch": "master"
         },
         "org.kde.KStyle.Adwaita/5.9": {


### PR DESCRIPTION
This should start phasing out Qt 5.11 as well

Note that I haven't pushed the Qt 5.12 branch to the repository yet, I'll do so when the patch is merged so we don't lose 5.11 builds.