### PR TITLE
Allow build result unpacking to take longer than 1200 seconds

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -605,6 +605,7 @@ class AddArchSteps(steps.BuildStep):
                     steps.ShellSequence(name='Extract ' + arch + ' build results',
                                         haltOnFailure=True,
                                         logEnviron=False,
+                                        timeout=3600,
                                         commands=[
                                             shellArg(['tar', 'xf', arch+'-repo.tar']),
                                             shellArg(['rm', arch+'-repo.tar'])


### PR DESCRIPTION
Apparently IO can be slow enough on repo that a large build result can take more than 1200 seconds and fail the whole build. KDE be sad. Until we have the repo manager...