### PR TITLE
Add io.liri.BaseApp stable branch

### DIFF
--- a/builds.json
+++ b/builds.json
@@ -115,6 +115,11 @@
             "repo": "default",
             "git-module": "io.liri.BaseApp.git",
             "git-branch": "5.11"
+        },
+        "io.liri.BaseApp/stable": {
+            "repo": "default",
+            "git-module": "io.liri.BaseApp.git",
+            "git-branch": "stable"
         }
     },
     /* Lists of all the apps maintained by its upstream. Please keep sorted. */


### PR DESCRIPTION
This allows much more flexibility and reduce changes to this file in the
future, because we can just update the stable branch instead of creating
a new branch each time.