### PR TITLE
Remove io.liri.BaseApp/5.11

### DIFF
--- a/builds.json
+++ b/builds.json
@@ -110,11 +110,6 @@
             "repo": "default",
             "git-module": "io.atom.electron.BaseApp.git",
             "git-branch": "master"
-        },
-        "io.liri.BaseApp/5.11": {
-            "repo": "default",
-            "git-module": "io.liri.BaseApp.git",
-            "git-branch": "5.11"
         }
     },
     /* Lists of all the apps maintained by its upstream. Please keep sorted. */


### PR DESCRIPTION
We will use the new branch names branch/<name> like branch/5.11
making this file irrelevant for io.liri.BaseApp.