### PR TITLE
Remove manual definitions of Electron2

### DIFF
--- a/builds.json
+++ b/builds.json
@@ -98,20 +98,10 @@
             "custom-buildcmd": true,
             "extra-prefixes": [ "org.gnome.Platform" ]
         },
-        "org.electronjs.Electron2.BaseApp/stable": {
-            "repo": "default",
-            "git-module": "org.electronjs.Electron2.BaseApp.git",
-            "git-branch": "1.6"
-        },
         "io.atom.electron.BaseApp/stable": {
             "repo": "default",
             "git-module": "io.atom.electron.BaseApp.git",
             "git-branch": "1.6"
-        },
-        "org.electronjs.Electron2.BaseApp/18.08": {
-            "repo": "default",
-            "git-module": "org.electronjs.Electron2.BaseApp.git",
-            "git-branch": "master"
         },
         "io.atom.electron.BaseApp/18.08": {
             "repo": "default",


### PR DESCRIPTION
So I believe this should just work as we have `branch/stable`, `branch/18.08`, and `branch/19.08` in the repo now.

Currently the latter is just failing because I guess its not defined here.

(Also after this is updated in the buildbot maybe trigger the builds)