### PR TITLE
Don't build org.kde.Sdk 5.15 for now

### DIFF
--- a/builds.json
+++ b/builds.json
@@ -62,14 +62,6 @@
             "git-branch": "qt5.14",
             "custom-buildcmd": true
         },
-        "org.kde.Sdk/5.15": {
-            "repo": "kde",
-            "base": "org.freedesktop.Sdk/19.08",
-            "git-module": "flatpak-kde-runtime",
-            "extra-prefixes": [ "org.kde.Platform" ],
-            "git-branch": "qt5.15lts",
-            "custom-buildcmd": true
-        },
         "org.freedesktop.Platform.GL.nvidia": {
             "repo": "default",
             "git-module": "org.freedesktop.Platform.GL.nvidia.git",


### PR DESCRIPTION
For some reason it never reached flathub, so it shouldn't be a problem.

According to the following discussion:
https://discourse.flathub.org/t/org-kde-sdk-5-15-0/526/12