### PR TITLE
Add builds for qt5.15lts-21.08

### DIFF
--- a/builds.json
+++ b/builds.json
@@ -41,6 +41,14 @@
             "git-branch": "qt5.15lts",
             "custom-buildcmd": true
         },
+        "org.kde.Sdk/5.15-21.08": {
+            "repo": "kde",
+            "base": "org.freedesktop.Sdk/21.08",
+            "git-module": "flatpak-kde-runtime",
+            "extra-prefixes": [ "org.kde.Platform" ],
+            "git-branch": "qt5.15lts-21.08",
+            "custom-buildcmd": true
+        },
         "org.freedesktop.Platform.GL.nvidia": {
             "repo": "default",
             "git-module": "org.freedesktop.Platform.GL.nvidia.git",


### PR DESCRIPTION
Since Qt is not releasing anymore, we are still maintaining the one based on their last release. Since there's a new SDK release, we decided to create a new version of ours based on it.
The naming is a bit wonky for sure, but at least we get to use the last versions of our base.