### PR TITLE
Add builds for qt5.15lts-22.08

### DIFF
--- a/builds.json
+++ b/builds.json
@@ -49,6 +49,14 @@
             "git-branch": "qt5.15lts-21.08",
             "custom-buildcmd": true
         },
+        "org.kde.Sdk/5.15-22.08": {
+            "repo": "kde",
+            "base": "org.freedesktop.Sdk/22.08",
+            "git-module": "flatpak-kde-runtime",
+            "extra-prefixes": [ "org.kde.Platform" ],
+            "git-branch": "qt5.15lts-22.08",
+            "custom-buildcmd": true
+        },
         "org.kde.Sdk/6.2": {
             "repo": "kde",
             "base": "org.freedesktop.Sdk/21.08",


### PR DESCRIPTION
To make sure to keep compatibilty for existing apps, we're not moving
the qt5.15lts-21.08 to the 22.08 FDO Runtime.

Thus we're creating a new qt5.15lts-22.08 branch and will be moving
existing apps to it progressively.

The version of Qt does not change between the two runtimes.